### PR TITLE
Fix: picture / observations urls

### DIFF
--- a/content/villes/châtillon/_index.fr.md
+++ b/content/villes/châtillon/_index.fr.md
@@ -7,4 +7,4 @@ title: Châtillon
 
 {{% umap 309113 %}}
 
-{{% get_issues "https://api.vigilo.vpchatillon.fr/get_issues.php?count=10" %}}
+{{% get_issues "https://api.vigilo.vpchatillon.fr" %}}

--- a/content/villes/marseille/_index.fr.md
+++ b/content/villes/marseille/_index.fr.md
@@ -7,4 +7,4 @@ title: Marseille(Beta)
 
 {{% umap 306383 "43.2942" "5.3757" %}}
 
-{{% get_issues "https://vigilo-beta.jesuisundesdeux.org/get_issues.php?scope=13_marseille&count=10" %}}
+{{% get_issues "https://vigilo-beta.jesuisundesdeux.org" "scope=13_marseille" %}}

--- a/content/villes/metz/_index.fr.md
+++ b/content/villes/metz/_index.fr.md
@@ -7,6 +7,4 @@ title: Metz(Beta)
 
 {{% umap 306383 "49.1196" "6.1946" %}}
 
-## Les 10 dernieres observations
-
-{{% get_issues "https://vigilo-beta.jesuisundesdeux.org/get_issues.php?scope=57_metz&count=10" %}}
+{{% get_issues "https://vigilo-beta.jesuisundesdeux.org" "scope=57_metz" %}}

--- a/content/villes/montpellier/_index.fr.md
+++ b/content/villes/montpellier/_index.fr.md
@@ -7,4 +7,4 @@ title: Montpellier
 
 {{% umap 286846 "43.6073" "3.9573" %}}
 
-{{% get_issues "https://vigilo.jesuisundesdeux.org/get_issues.php?count=10" %}}
+{{% get_issues "https://vigilo.jesuisundesdeux.org" %}}

--- a/content/villes/troyes/_index.fr.md
+++ b/content/villes/troyes/_index.fr.md
@@ -9,4 +9,4 @@ title: Troyes(Beta)
 
 </iframe>
 
-{{% get_issues "http://api.vigilo.troyesenselle.fr/get_issues.php?count=10" %}}
+{{% get_issues "http://api.vigilo.troyesenselle.fr" %}}

--- a/layouts/shortcodes/get_issues.html
+++ b/layouts/shortcodes/get_issues.html
@@ -1,8 +1,9 @@
 ## Les 10 dernières observations
 
-{{ $issues := getJSON ($.Get 0)}}
-| Adresse | Commentaire | Liens |
-| ----- | ------- | ----------- |
+{{ $issues := getJSON (.Get 0) "/get_issues.php?count=10&" (.Get 1) }}
+{{ $api  := (.Get 0) }}
+| date | Adresse | Commentaire | Liens |
+| ----- | ----- | ------- | ----------- |
 {{- range $issues }}
-| {{ .address }} | {{ .comment }} | [Photo](https://vigilo.jesuisundesdeux.org/generate_panel.php?token={{ .token }}) - [Observations similaires](https://vigilo.jesuisundesdeux.org/mosaic.php?t={{ .token }}) |
+| {{ .time }} | {{ .address }} | {{ .comment }} | [Photo]({{ $api }}/generate_panel.php?token={{ .token }}) - [Observations similaires]({{ $api }}/mosaic.php?t={{ .token }}) |
 {{- end }}

--- a/layouts/shortcodes/get_issues.html
+++ b/layouts/shortcodes/get_issues.html
@@ -2,8 +2,8 @@
 
 {{ $issues := getJSON (.Get 0) "/get_issues.php?count=10&" (.Get 1) }}
 {{ $api  := (.Get 0) }}
-| date | Adresse | Commentaire | Liens |
-| ----- | ----- | ------- | ----------- |
+| Adresse | Commentaire | Liens |
+| ----- | ------- | ----------- |
 {{- range $issues }}
-| {{ .time }} | {{ .address }} | {{ .comment }} | [Photo]({{ $api }}/generate_panel.php?token={{ .token }}) - [Observations similaires]({{ $api }}/mosaic.php?t={{ .token }}) |
+| {{ .address }} | {{ .comment }} | [Photo]({{ $api }}/generate_panel.php?token={{ .token }}) - [Observations similaires]({{ $api }}/mosaic.php?t={{ .token }}) |
 {{- end }}


### PR DESCRIPTION
# Fonctionnalités
* Change le lien des photos grand format en fonction de [la ville dans les 10 dernières observations](https://vigilo.city/fr/villes/marseille/)
![Screenshot from 2019-05-01 21-28-47](https://user-images.githubusercontent.com/4059615/57037682-24183980-6c58-11e9-91f9-dbc8d5e02ff7.png)


